### PR TITLE
[#9]; chore: update root gitignore for terraform artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Terraform variable files
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
+
+# CLI configs
+.terraformrc
+terraform.rc
+
+# OS / editor
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/


### PR DESCRIPTION
Resolves #9

- ignore .terraform directories
- ignore tfstate and crash logs
- keep *.tfvars.example tracked