### PR TITLE
[#22]; chore: storage.tf 포맷 재정렬

### DIFF
--- a/terraform/environments/dev/training/storage.tf
+++ b/terraform/environments/dev/training/storage.tf
@@ -3,7 +3,7 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  data_lake_bucket_arn       = "arn:${data.aws_partition.current.partition}:s3:::${var.data_lake_bucket_name}"
-  duplicate_guard_table_arn  = "arn:${data.aws_partition.current.partition}:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${local.duplicate_guard_table_name}"
-  crawl_dlq_arn              = var.crawl_dlq_arn != "" ? var.crawl_dlq_arn : "arn:${data.aws_partition.current.partition}:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${local.crawl_dlq_name}"
+  data_lake_bucket_arn      = "arn:${data.aws_partition.current.partition}:s3:::${var.data_lake_bucket_name}"
+  duplicate_guard_table_arn = "arn:${data.aws_partition.current.partition}:dynamodb:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${local.duplicate_guard_table_name}"
+  crawl_dlq_arn             = var.crawl_dlq_arn != "" ? var.crawl_dlq_arn : "arn:${data.aws_partition.current.partition}:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${local.crawl_dlq_name}"
 }


### PR DESCRIPTION
## What changed
- ran `terraform fmt` for `terraform/environments/dev/training/storage.tf`
- normalized the `locals` block spacing so `terraform fmt -check` passes in deploy

## Why
The deploy workflow stopped before `plan` because `terraform fmt -check` failed on `storage.tf` after the previous refactor to reference existing training resources directly.

## Impact
This unblocks the `deploy.yml` workflow for the dev training Terraform stack without changing runtime behavior.

## Validation
- `terraform -chdir=terraform/environments/dev/training fmt`
